### PR TITLE
Add support for custom http.Client

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -38,13 +38,23 @@ var (
 
 // FCM  stores client with api key to firebase
 type FCM struct {
-	APIKey string
+	APIKey     string
+	HttpClient *http.Client
 }
 
 // NewFCM creates a new client
 func NewFCM(apiKey string) *FCM {
 	return &FCM{
-		APIKey: apiKey,
+		APIKey:     apiKey,
+		HttpClient: &http.Client{},
+	}
+}
+
+// NewFCM creates a new client
+func NewFCMWithClient(apiKey string, httpClient *http.Client) *FCM {
+	return &FCM{
+		APIKey:     apiKey,
+		HttpClient: httpClient,
 	}
 }
 
@@ -67,8 +77,7 @@ func (f *FCM) Send(message Message) (Response, error) {
 	req.Header.Set("Authorization", f.AuthorizationToken())
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := f.HttpClient.Do(req)
 	if err != nil {
 		return Response{}, err
 	}

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -39,7 +39,7 @@ func TestSendMessageCanSendToMultipleRegIDs(t *testing.T) {
 
 	defer srv.Close()
 
-	c := NewFCM("key")
+	c := NewFCMWithClient("key", &http.Client{})
 
 	data := map[string]string{
 		"msg": "Hello World",


### PR DESCRIPTION
In appengine you cant use the default http.Client. I needed a custom urlfetch.Client (wich maches the http.Client interface).

However there was no way to submit a custom client.
My simple code change allows this. Its backwards compatible.

The log file from Appengine logs:

> Post https://fcm.googleapis.com/fcm/send: http.DefaultTransport and http.DefaultClient are not available in App Engine. See https://cloud.google.com/appengine/docs/go/urlfetch/