### PR TITLE
Unmarshal downstream results into a struct

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -101,11 +101,9 @@ func (f *FCM) Send(message Message) (Response, error) {
 // Failed method indicates if the server couldn't process
 // the request in time.
 func (f *FCM) Failed(response *Response) error {
-	for _, val := range response.Results {
-		for k, v := range val {
-			if k == ErrorKey && retryableErrors[v] {
-				return fmt.Errorf("Failed %s", k)
-			}
+	for _, response := range response.Results {
+		if retryableErrors[response.Error] {
+			return fmt.Errorf("Failed %s", response.Error)
 		}
 	}
 

--- a/models.go
+++ b/models.go
@@ -94,11 +94,21 @@ type (
 		Condition string `json:"condition,omitempty"`
 	}
 
-	// Result from FCM, sent in the "results" field of the Response packet
+	// Downstream result from FCM, sent in the "results" field of the Response packet
 	Result struct {
-		MessageID      string `json:"message_id"`
+		// String specifying a unique ID for each successfully processed message.
+		MessageID string `json:"message_id"`
+
+		// Optional string specifying the canonical registration token for the
+		// client app that the message was processed and sent to. Sender should
+		// use this value as the registration token for future requests.
+		// Otherwise, the messages might be rejected.
 		RegistrationID string `json:"registration_id"`
-		Error          string `json:"error"`
+
+		// String specifying the error that occurred when processing the message
+		// for the recipient. The possible values can be found in table 9 here:
+		// https://firebase.google.com/docs/cloud-messaging/http-server-ref#table9
+		Error string `json:"error"`
 	}
 
 	// Response represents fcm response message - (tokens and topics)

--- a/models.go
+++ b/models.go
@@ -94,6 +94,13 @@ type (
 		Condition string `json:"condition,omitempty"`
 	}
 
+	// Result from FCM, sent in the "results" field of the Response packet
+	Result struct {
+		MessageID      string `json:"message_id"`
+		RegistrationID string `json:"registration_id"`
+		Error          string `json:"error"`
+	}
+
 	// Response represents fcm response message - (tokens and topics)
 	Response struct {
 		Ok         bool
@@ -118,7 +125,7 @@ type (
 		// message_id: String specifying a unique ID for each successfully processed message.
 		// registration_id: Optional string specifying the canonical registration token for the client app that the message was processed and sent to. Sender should use this value as the registration token for future requests. Otherwise, the messages might be rejected.
 		// error: String specifying the error that occurred when processing the message for the recipient. The possible values can be found in table 9.
-		Results []map[string]string `json:"results,omitempty"`
+		Results []Result `json:"results,omitempty"`
 
 		// The topic message ID when FCM has successfully received the request and will attempt to deliver to all subscribed devices.
 		MsgID int `json:"message_id,omitempty"`


### PR DESCRIPTION
Downstream message response results seem to have a stable message structure:

https://firebase.google.com/docs/cloud-messaging/http-server-ref#interpret-downstream

So this just puts those result into a struct.
