### PR TITLE
Change type of multicast_id from int to uint64

### DIFF
--- a/models.go
+++ b/models.go
@@ -122,7 +122,7 @@ type (
 		StatusCode int
 
 		// MulticastID a unique ID (number) identifying the multicast message.
-		MulticastID int `json:"multicast_id"`
+		MulticastID uint64 `json:"multicast_id"`
 
 		// Success number of messages that were processed without an error.
 		Success int `json:"success"`


### PR DESCRIPTION
With using this library we get an error on unmarshalling multicast_id to int, like this
```
Sending the notification failed: json: cannot unmarshal number 5618853696839826700 into Go struct field Response.multicast_id of type int
```

This PR changes is to use unsigned int which is capable to fit the large number.